### PR TITLE
Sync Dockerfile-frontend with upstream to fix docker-compose build

### DIFF
--- a/Dockerfile-frontend
+++ b/Dockerfile-frontend
@@ -4,13 +4,16 @@
 # Use a docker image with NODE to build the deliverable
 # Build everywhere
 ####################################################################
+ARG DOCKER_HUB="docker.io"
+ARG NGINX_VERSION="1.17.6"
+ARG NODE_VERSION="16.3-alpine"
 
-FROM node:12 as build
+FROM $DOCKER_HUB/library/node:$NODE_VERSION as build
 MAINTAINER Cedrick Lunven
 
 # Get Sources
-RUN apt update && \
- 	apt install -y git && \
+RUN apk update && \
+        apk add git && \
 	git clone https://github.com/spring-petclinic/spring-petclinic-angular.git /workspace
 
 ARG NPM_REGISTRY=" https://registry.npmjs.org"
@@ -27,7 +30,8 @@ RUN echo "export const environment = {production: false, REST_API_URL:  'http://
 # Use the DIST folder to package an image with NGINX.
 ####################################################################
 
-FROM nginx:1.19.4 AS runtime
+FROM $DOCKER_HUB/library/nginx:$NGINX_VERSION AS runtime
+
 
 COPY  --from=build /workspace/dist/ /usr/share/nginx/html/
 


### PR DESCRIPTION
This PR pulls in the [upstream changes](https://github.com/spring-petclinic/spring-petclinic-angular/blob/f1b95b4e62f93944b2abdb273f199dc5077f8e57/Dockerfile) to the `Dockerfile-frontend` file. The existing dockerfile was using an old image base, which no longer builds because the debian packages are no longer available

Testing Done: Verified that `docker-compose build` is successful and that the application works